### PR TITLE
Sam/version compare single view

### DIFF
--- a/dle/compare/static/compare/styles.css
+++ b/dle/compare/static/compare/styles.css
@@ -21,20 +21,20 @@
     border:3px solid black;
 }
 
-.sec-match > div {
+/* highlight green if the sections are exact matches */
+.matching-section {
     border:3px solid green;
+    vertical-align: top;
 }
 
-/* .sec-diff > div {
+/* highlight red if the sections have diffs */
+.diff-section {
     border:3px solid red;
-} */
+    vertical-align: top;
+}
 
 .diff-text-highlight {
     background-color:rgba(240, 14, 14, 0.575);
-}
-
-.matching-text-highlight {
-    background-color:rgba(14, 240, 74, 0.575);
 }
 
 .error-msg-display {

--- a/dle/compare/static/compare/styles.css
+++ b/dle/compare/static/compare/styles.css
@@ -9,27 +9,25 @@
 }
 
 .row {
-    margin: 10px;
-    /* padding-left: 10px;  */
+    margin: 1px;
+    padding-left: 10px; 
 }
 
 .sec-header > div {
+    margin-left: 5px;
+    margin-right: 5px;
     text-align: center;
-}
-
-.sec-content > div {
-    margin-left: 10px;
-    padding-left: 1px;
     border-radius: 8px;
+    border:3px solid black;
 }
 
 .sec-match > div {
     border:3px solid green;
 }
 
-.sec-diff > div {
+/* .sec-diff > div {
     border:3px solid red;
-}
+} */
 
 .diff-text-highlight {
     background-color:rgba(240, 14, 14, 0.575);
@@ -41,4 +39,41 @@
 
 .error-msg-display {
     background-color:rgba(240, 14, 14, 0.575);
+}
+
+/* Style the button that is used to open and close the collapsible content */
+.collapsible {
+    background-color:rgb(149, 210, 238);
+    color: #444;
+    cursor: pointer;
+    margin-left: 10px;
+    padding: 18px;
+    width: 100%;
+    text-align: left;
+    outline: auto;
+    font-size: 15px;
+}
+  
+/* Add a background color to the button if it is clicked on and when moving the mouse over it (hover) */
+.active, .collapsible:hover {
+    background-color: #ccc;
+}
+  
+/* Style the collapsible content. Note: hidden by default */
+.sec-content {
+    display: none;
+    overflow: hidden;
+    background-color: #f1f1f1;
+}
+  
+.section-table {
+    table-layout: fixed;
+    border: 1px solid black;
+    border-collapse: collapse;
+    width: 100%;
+}
+  
+.section-td {
+    border: 3px solid black;
+    vertical-align: top;
 }

--- a/dle/compare/templates/compare/compare_labels.html
+++ b/dle/compare/templates/compare/compare_labels.html
@@ -1,0 +1,98 @@
+
+{% extends "compare/layout.html" %}
+{% block header %}
+{% endblock header %}
+
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            {% if dl3 %}
+            <h6> Comparing drugs 
+                <b>{{dl1.product_name}}</b>, 
+                <b>{{dl2.product_name}}</b>, and 
+                <b>{{dl3.product_name}}</b>:
+            </h6>
+            {% else %}
+            <h6> Comparing drugs 
+                <b>{{dl1.product_name}}</b>, and 
+                <b>{{dl2.product_name}}</b>:
+            </h6>
+            {% endif %}
+        </div>
+        <br>
+        <div class="row">
+            <table class="section-table">
+            <tr>
+            <td class="section-td">
+                <dl>
+                    <dt>Product Name: {{ dl1.product_name }}</dt>
+                    <dt>Generic Name: {{ dl1.generic_name }}</dt>
+                    <dt>Version Date: {{ dl1.version_date }}</dt>
+                    <dt>Product Number: {{ dl1.source_product_number }}</dt>
+                    <dt>Marketer: {{ dl1.marketer }}</dt>
+                    <dt>Source: {{ dl1.source }}</dt>
+                </dl>
+            </td>
+            <td class="section-td">
+                <dl>
+                    <dt>Product Name: {{ dl2.product_name }}</dt>
+                    <dt>Generic Name: {{ dl2.generic_name }}</dt>
+                    <dt>Version Date: {{ dl2.version_date }}</dt>
+                    <dt>Product Number: {{ dl2.source_product_number }}</dt>
+                    <dt>Marketer: {{ dl2.marketer }}</dt>
+                    <dt>Source: {{ dl2.source }}</dt>
+                </dl>
+            </td>
+            {% if dl3 %}
+                <td class="section-td"> 
+                    <dl>
+                        <dt>Product Name: {{ dl3.product_name }}</dt>
+                        <dt>Generic Name: {{ dl3.generic_name }}</dt>
+                        <dt>Version Date: {{ dl3.version_date }}</dt>
+                        <dt>Product Number: {{ dl3.source_product_number }}</dt>
+                        <dt>Marketer: {{ dl3.marketer }}</dt>
+                        <dt>Source: {{ dl3.source }}</dt>
+                    </dl>
+                </td>
+            {% endif %}
+            </tr>
+            </table>
+        </div>
+        {% if sections %}
+            {% for section in sections %}
+                <button type="button" class="collapsible"> > {{ section.section_name }}</button>
+                <div class="row sec-content" style="display:none">
+                    <table class="section-table">
+                        <tr>
+                          <td class="section-td"><p>{{ section.section_text1|safe }}</p></td>
+                          <td class="section-td"><p>{{ section.section_text2|safe }}</p></td>
+                          {% if section.section_text3 %}
+                            <td class="section-td"><p>{{ section.section_text3|safe }}</p></td>
+                          {% endif %}
+                        </tr>
+                    </table>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>No section texts are found.</p>
+        {% endif %}
+    </div>
+{% endblock content %}
+{% block footer_scripts %}
+    <script>
+        var coll = document.getElementsByClassName("collapsible");
+        var i;
+
+        for (i = 0; i < coll.length; i++) {
+            coll[i].addEventListener("click", function() {
+                this.classList.toggle("active");
+                var content = this.nextElementSibling;
+                if (content.style.display === "block") {
+                    content.style.display = "none";
+                } else {
+                    content.style.display = "block";
+                }
+            });
+        }
+    </script>
+{% endblock footer_scripts %}

--- a/dle/compare/templates/compare/compare_labels.html
+++ b/dle/compare/templates/compare/compare_labels.html
@@ -80,9 +80,17 @@
 {% endblock content %}
 {% block footer_scripts %}
     <script>
+        /**
+         * Get all section heading button elements
+         */
         var coll = document.getElementsByClassName("collapsible");
         var i;
 
+        /**
+         * Add event listener to all buttons to make section content 
+         * collapsible. When a section button is clicked, the section 
+         * content will show or hide.
+         */
         for (i = 0; i < coll.length; i++) {
             coll[i].addEventListener("click", function() {
                 this.classList.toggle("active");

--- a/dle/compare/templates/compare/compare_versions.html
+++ b/dle/compare/templates/compare/compare_versions.html
@@ -1,0 +1,104 @@
+
+{% extends "compare/layout.html" %}
+{% block header %}
+{% endblock header %}
+
+{% block content %}
+    <div class="container-fluid">
+        <div class="row">
+            <h6> Comparing drugs {{dl1.product_name}}, 
+                <b>version ({{dl1.version_date }})</b>, and 
+                <b>version ({{dl2.version_date }})</b>:
+            </h6>
+        </div>
+        <br>
+        <div class="row">
+            <table class="section-table">
+            <tr>
+                <td class="section-td">
+                    <dl>
+                        <dt>Product Name: {{ dl1.product_name }}</dt>
+                        <dt>Generic Name: {{ dl1.generic_name }}</dt>
+                        <dt>Version Date: {{ dl1.version_date }}</dt>
+                        <dt>Product Number: {{ dl1.source_product_number }}</dt>
+                        <dt>Marketer: {{ dl1.marketer }}</dt>
+                        <dt>Source: {{ dl1.source }}</dt>
+                    </dl>
+                </td>
+                <td class="section-td">
+                    <dl>
+                        <dt>Product Name: {{ dl2.product_name }}</dt>
+                        <dt>Generic Name: {{ dl2.generic_name }}</dt>
+                        <dt>Version Date: {{ dl2.version_date }}</dt>
+                        <dt>Product Number: {{ dl2.source_product_number }}</dt>
+                        <dt>Marketer: {{ dl2.marketer }}</dt>
+                        <dt>Source: {{ dl2.source }}</dt>
+                    </dl>
+                </td>
+            </tr>
+            </table>
+        </div>
+        {% if sections %}
+            {% for section in sections %}
+                <button type="button" class="collapsible"> > {{ section.section_name }}</button>
+                <div class="row sec-content" style="display:none">
+                    <table class="section-table">
+                        <tr>
+                          <td class="{{ section.textMatches }}">
+                              <p>
+                                {% for tuple in section.section_text1 %}
+                                    {% if tuple.0 == 0 %}
+                                        {{ tuple.1|safe }}
+                                    {% elif tuple.0 == -1 %}
+                                        <span class="diff-text-highlight">{{ tuple.1 }}</span>
+                                    {% endif %}
+                                {% endfor %}
+                              </p>
+                            </td>
+                          <td class="{{ section.textMatches }}">
+                              <p>
+                                {% for tuple in section.section_text2 %}
+                                    {% if tuple.0 == 0 %}
+                                        {{ tuple.1|safe }}
+                                    {% elif tuple.0 == 1 %}
+                                        <span class="diff-text-highlight">{{ tuple.1 }}</span>
+                                    {% endif %}
+                                {% endfor %}
+
+                              </p>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>No section texts are found.</p>
+        {% endif %}
+    </div>
+{% endblock content %}
+{% block footer_scripts %}
+    <script>
+        /**
+         * Get all section heading button elements
+         */
+        var coll = document.getElementsByClassName("collapsible");
+        var i;
+
+        /**
+         * Add event listener to all buttons to make section content 
+         * collapsible. When a section button is clicked, the section 
+         * content will show or hide.
+         */
+        for (i = 0; i < coll.length; i++) {
+            coll[i].addEventListener("click", function() {
+                this.classList.toggle("active");
+                var content = this.nextElementSibling;
+                if (content.style.display === "block") {
+                    content.style.display = "none";
+                } else {
+                    content.style.display = "block";
+                }
+            });
+        }
+    </script>
+{% endblock footer_scripts %}

--- a/dle/compare/templates/compare/index.html
+++ b/dle/compare/templates/compare/index.html
@@ -1,6 +1,6 @@
 {% extends "compare/layout.html" %}
 
-{% block body content %}
+{% block content %}
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-8">

--- a/dle/compare/templates/compare/index.html
+++ b/dle/compare/templates/compare/index.html
@@ -1,6 +1,6 @@
 {% extends "compare/layout.html" %}
 
-{% block body %}
+{% block body content %}
     <div class="container">
         <div class="row justify-content-center">
             <div class="col-8">
@@ -52,16 +52,6 @@
             </div>
         </div>
     </div>
-    
-
-    <!-- {% if pname_version %}
-        <ul>
-            {% for item in pname_version %}
-                <ol>{{ item }}</ol>
-            {% endfor %}
-        </ul>
-    {% endif %} -->
-
-{% endblock %}
+{% endblock content %}
 
 

--- a/dle/compare/templates/compare/layout.html
+++ b/dle/compare/templates/compare/layout.html
@@ -6,6 +6,7 @@
         <title>{% block title %}Compare{% endblock %}</title>
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
         <link href="{% static 'compare/styles.css' %}" rel="stylesheet">
+        {% block header %}{% endblock header %}
     </head>
     <body>
         <ul class="nav justify-content-center">
@@ -30,7 +31,9 @@
             <!-- {% endif %} -->
         </ul>
         <hr>
-        {% block body %}
-        {% endblock %}
+        <!-- {% block body %}
+        {% endblock %} -->
+        {% block content %}{% endblock content %}
+        {% block footer_scripts %}{% endblock footer_scripts %}
     </body>
 </html>

--- a/dle/compare/templates/compare/layout.html
+++ b/dle/compare/templates/compare/layout.html
@@ -12,21 +12,21 @@
         <ul class="nav justify-content-center">
             <!-- TODO: all links route back to compare/index for now-->
             <li class="nav-item">
-                <a class="nav-link" href="{% url 'compare:index' %}">Main search</a>
+                <a class="nav-link" href=/search/ >Home</a>
             </li>
             <!-- {% if user.is_authenticated %}
                 <li class="nav-item">
                     Signed in as <strong>{{ user.username }}</strong>
                 </li> -->
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'compare:index' %}">Log Out</a>
+                    <a class="nav-link" href=/users/logout >Log Out</a>
                 </li>
             <!-- {% else %} -->
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'compare:index' %}">Log In</a>
+                    <a class="nav-link" href=/users/login >Log In</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="{% url 'compare:index' %}">Register</a>
+                    <a class="nav-link" href=/users/register >Register</a>
                 </li>
             <!-- {% endif %} -->
         </ul>

--- a/dle/compare/urls.py
+++ b/dle/compare/urls.py
@@ -6,5 +6,6 @@ app_name = 'compare'
 urlpatterns = [
     path('', views.index, name='index'),
     path('list_labels', views.list_labels, name='list_labels'),
+    path('compare_labels', views.compare_labels, name='compare_labels'),
     path('compare_result', views.compare_result, name='compare_result'),
 ]

--- a/dle/compare/urls.py
+++ b/dle/compare/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('list_labels', views.list_labels, name='list_labels'),
     path('compare_labels', views.compare_labels, name='compare_labels'),
+    path('compare_versions', views.compare_versions, name='compare_versions'),
     path('compare_result', views.compare_result, name='compare_result'),
 ]

--- a/dle/compare/util.py
+++ b/dle/compare/util.py
@@ -4,30 +4,6 @@ import gensim
 from gensim.parsing.preprocessing import remove_stopwords
 from .models import *
 
-SECTION_NAMES_DICT = {
-    'INDICATIONS': 'Indications',
-    'CONTRA': 'Contraindications',
-    'WARN': 'Warnings',
-    'PREG': 'Pregnancy',
-    'POSE': 'Posology',
-    'INTERACT': 'Interactions',
-    'DRIVE': 'Effects on driving',
-    'SIDE': 'Side effects',
-    'OVER': 'Overdose',
-    "('INDICATIONS', 'Indications')": 'Indications',
-    "('CONTRA', 'Contraindications')": 'Contraindications',
-    "('WARN', 'Warnings')": 'Warnings',
-    "('PREG', 'Pregnancy')": 'Pregnancy',
-    "('POSE', 'Posology')": 'Posology',
-    "('INTERACT', 'Interactions')": 'Interactions',
-    "('DRIVE', 'Effects on driving')": 'Effects on driving',
-    "('SIDE', 'Side effects')": 'Side effects',
-    "('OVER', 'Overdose')": 'Overdose',
-}
-
-def map_section_names(str):
-    return SECTION_NAMES_DICT[str]
-
 def get_diff_for_diff_versions(text1, text2):
     dmp = dmp_module.diff_match_patch()
     diff = dmp.diff_main(text1, text2)

--- a/dle/compare/views.py
+++ b/dle/compare/views.py
@@ -30,7 +30,11 @@ def list_labels(request: HttpRequest) -> HttpResponse:
 
 
 def compare_labels(request: HttpRequest) -> HttpResponse:
-    """
+    """Compare 2 or 3 different drug labels view
+    Args:
+        request (HttpRequest): GET request with 2 or 3 drug label ids
+    Returns:
+        HttpResponse: Side-by-side view of 2 or 3 drug labels for each section
     """
     drug_label1 = get_object_or_404(DrugLabel, id = request.GET['first-label'])
     drug_label2 = get_object_or_404(DrugLabel, id = request.GET['second-label'])

--- a/dle/compare/views.py
+++ b/dle/compare/views.py
@@ -1,15 +1,16 @@
 from django.shortcuts import render, get_object_or_404
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 from django.core.exceptions import ObjectDoesNotExist
 from .models import *
 from .util import *
 
 
-def index(request):
+def index(request: HttpRequest) -> HttpResponse:
+    """ Compare view's landing page. Might not be needed later."""
     return render(request, 'compare/index.html')
 
 
-def list_labels(request):
+def list_labels(request: HttpRequest) -> HttpResponse:
     context = { 'labelsFound': False}
     drug_labels1 = DrugLabel.objects.filter(product_name = request.GET['first-label'])
     if drug_labels1:
@@ -26,6 +27,80 @@ def list_labels(request):
         context["labelsFound"] = True
 
     return render(request, 'compare/index.html', context)
+
+
+def compare_labels(request: HttpRequest) -> HttpResponse:
+    """
+    """
+    drug_label1 = get_object_or_404(DrugLabel, id = request.GET['first-label'])
+    drug_label2 = get_object_or_404(DrugLabel, id = request.GET['second-label'])
+
+    try:
+        label_product1 = LabelProduct.objects.filter(drug_label = drug_label1).first()
+        dl1_sections = ProductSection.objects.filter(label_product = label_product1)
+    except ObjectDoesNotExist:
+        dl1_sections = []
+
+    try:
+        label_product2 = LabelProduct.objects.filter(drug_label = drug_label2).first()
+        dl2_sections = ProductSection.objects.filter(label_product = label_product2)
+    except ObjectDoesNotExist:
+        dl2_sections = []
+
+    context = { 'dl1': drug_label1, 'dl2': drug_label2}
+
+    # get dict in the form {section_name: [section_text1, section_text2, section_text3]}
+    sections_dict = {}
+
+    for section in dl1_sections:
+        sections_dict[section.section_name] = { 
+            "section_name": section.section_name, 
+            "textMatches": "sec-diff",
+            "section_text1": section.section_text,
+            "section_text2": "Section/subsection doesn't exist for this drug label.",
+            }
+    
+    for section in dl2_sections:
+        if section.section_name in sections_dict.keys():
+            sections_dict[section.section_name]["section_text2"] = section.section_text
+        else:
+            sections_dict[section.section_name] = { 
+                "section_name": section.section_name,
+                "textMatches": "sec-diff",
+                "section_text1": "Section/subsection doesn't exist for this drug label.",
+                "section_text2": section.section_text,
+            }
+
+    if 'third-label' in request.GET:
+        print("third-label requested")
+        drug_label3 = get_object_or_404(DrugLabel, id = request.GET['third-label'])
+        try:
+            label_product3 = LabelProduct.objects.filter(drug_label = drug_label3).first()
+            dl3_sections = ProductSection.objects.filter(label_product = label_product3)
+            context['dl3'] = drug_label3
+
+            for section_name in sections_dict.keys():
+                sections_dict[section_name]["section_text3"] = "Section/subsection doesn't exist for this drug label."
+
+            for section in dl3_sections:
+                if section.section_name in sections_dict.keys():
+                    sections_dict[section.section_name]["section_text3"] = section.section_text
+                else:
+                    sections_dict[section.section_name] = { 
+                        "section_name": section.section_name,
+                        "textMatches": "sec-diff",
+                        "section_text1": "Section/subsection doesn't exist for this drug label.",
+                        "section_text2": "Section/subsection doesn't exist for this drug label.",
+                        "section_text3": section.section_text,
+                    }
+
+        except ObjectDoesNotExist:
+            dl3_sections = []
+
+    context["sections"] = [v for k, v in sections_dict.items()]
+    context['text_highlight'] = "matching-text-highlight"
+
+    return render(request, 'compare/compare_labels.html', context)
 
 
 def compare_result(request):

--- a/dle/data/templates/data/single_label.html
+++ b/dle/data/templates/data/single_label.html
@@ -1,24 +1,124 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>Drug Label</title>
-  </head>
-  <body>
-<h1>{{ drug_label.product_name }}</h1>
-<h3>{{ drug_label.generic_name }}</h3>
-<p>Label date: {{ drug_label.version_date }}</p>
-<p>Source: {{ drug_label.source }}</p>
-<p>Product Number: {{ drug_label.source_product_number }}</p>
-<p>Marketing Authorization Holder: {{ drug_label.marketer }}</p>
-<a href="{{ drug_label.link }}">Link</a>
-<p>Label Product Sections:</p>
-{% for section in product_sections %}
-  <h4>{{ section.section_name }}</h4>
-  <p>{{ section.section_text|safe }}</p>
-{% endfor %}
-  </body>
-</html>
+{% extends "compare/layout.html" %}
+{% block content %}
+  <div>
+    <h1> {{ drug_label.product_name }}</h1>
+    <dl>
+      <dt>Generic Name: <b>{{ drug_label.generic_name }}</b></dt>
+      <dt>Version Date: <b>{{ drug_label.version_date }}</b></dt>
+      <dt>Product Number: <b>{{ drug_label.source_product_number }}</b></dt>
+      <dt>Marketing Authorization Holder: <b>{{ drug_label.marketer }}</b></dt>
+      <dt>Source: <b>{{ drug_label.source }}</b></dt>
+      <dt>Go to this <a href="{{ drug_label.link }}">Link</a> for the original source document.</dt>
+      <dt></dt>
+    </dl>
+  </div>
 
+  <hr>
+  <div class="container-fluid">
+    <h5>List of all versions of <b>{{drug_label.product_name}}:</b></h5>
+    <form name="result_to_compare_form" method="get" action="/compare/compare_versions" target="_blank">
+      {% for label in drug_label_versions %}
+      <div class="form-check">
+        <label class="form-check-label" for="{{label.id}}">
+          <input type="checkbox" class="form-check-input compare-checkbox" onclick="_versions_handleSelectClick()" value={{label.id}} />
+          <a href=/data/{{label.id}} class="text-sml text-stone-900" target="_blank">
+            <h6 class="text-xl text-blue-700 group-hover:underline">
+              {{label.product_name}} ({{label.version_date}})
+            </h6>
+          </a>
+        </label>
+      </div>
+      {% endfor %}
+      <button type="button" onclick="_versions_handleCompareSubmit()" class="btn btn-primary">
+
+        Compare Two Versions
+      </button>
+    </form>
+  </div>
+  <br>
+  {% for section in product_sections %}
+    <hr>
+    <h5>{{ section.section_name }}</h5>
+    <p>{{ section.section_text|safe }}</p>
+  {% endfor %}
+{% endblock content %}
+{% block footer_scripts %}
+  <script>
+    const _versions_COMPARE_CHECKBOX = "compare-checkbox";
+    /**
+     * Checks if the selected results is at the max limit
+     * @param {NodeListOf<Element>} selectedNodes - List of checkboxes that are selected
+     * @param {Optional<number>} limit - The number of allowed "selected" checkboxes
+     * @return {bool} True if number of selected checkboxes is at the limit
+     */
+    function _versions_isAtLimit(selectedNodes) {
+      return selectedNodes.length === 2;
+    }
+
+    /**
+     * Disables all unselected search result checkboxes
+     */
+    function _versions_disableRemainingCheckboxes() {
+      document
+        .querySelectorAll(`input.${_versions_COMPARE_CHECKBOX}:not(:checked)`)
+        .forEach((node) => (node.disabled = true));
+    }
+
+    /**
+     * Enables all disabled checkboxes
+     */
+    function _versions_enableRemainingCheckboxes() {
+      document
+        .querySelectorAll(`input.${_versions_COMPARE_CHECKBOX}:disabled`)
+        .forEach((node) => (node.disabled = false));
+    }
+
+    /**
+     * Fired every time the user clicks on the checkbox
+     * Essentially limits the user to just 2 drug labels to compare.
+     */
+    function _versions_handleSelectClick() {
+      const selectedResults = document.querySelectorAll(
+        `input.${_versions_COMPARE_CHECKBOX}:checked`
+      );
+      _versions_isAtLimit(selectedResults)
+        ? _versions_disableRemainingCheckboxes()
+        : _versions_enableRemainingCheckboxes();
+    }
+
+    /**
+     * Fired when the user clicks the "compare" button
+     * Only redirect's the user if the selected labels is at the "limit"
+     *    i.e. comparing 2 selected labels requires 2 selected labels
+     */
+    function _versions_handleCompareSubmit() {
+      const selectedResults = document.querySelectorAll(
+        `input.${_versions_COMPARE_CHECKBOX}:checked`
+      );
+
+      const selectedResults_length = selectedResults.length;
+
+      if (selectedResults.length >= 2) {
+        const [firstDrug, secondDrug] = selectedResults;
+        firstDrug.name = 'first-label';
+        secondDrug.name = 'second-label';
+
+        if (selectedResults.length === 3) {
+          const thirdDrug = selectedResults[2];
+          thirdDrug.name = 'third-label';
+        }
+
+        // open the compare page in new tab
+        document.result_to_compare_form.submit();
+
+        return;
+      }
+      else {
+        window.alert("Please select 2 or 3 labels to compare.");
+        return;
+      }
+    }
+  </script>
+{% endblock %}
 
 

--- a/dle/data/templates/data/single_label.html
+++ b/dle/data/templates/data/single_label.html
@@ -1,47 +1,47 @@
 {% extends "compare/layout.html" %}
 {% block content %}
-  <div>
-    <h1> {{ drug_label.product_name }}</h1>
-    <dl>
-      <dt>Generic Name: <b>{{ drug_label.generic_name }}</b></dt>
-      <dt>Version Date: <b>{{ drug_label.version_date }}</b></dt>
-      <dt>Product Number: <b>{{ drug_label.source_product_number }}</b></dt>
-      <dt>Marketing Authorization Holder: <b>{{ drug_label.marketer }}</b></dt>
-      <dt>Source: <b>{{ drug_label.source }}</b></dt>
-      <dt>Go to this <a href="{{ drug_label.link }}">Link</a> for the original source document.</dt>
-      <dt></dt>
-    </dl>
-  </div>
-
-  <hr>
   <div class="container-fluid">
-    <h5>List of all versions of <b>{{drug_label.product_name}}:</b></h5>
-    <form name="result_to_compare_form" method="get" action="/compare/compare_versions" target="_blank">
-      {% for label in drug_label_versions %}
-      <div class="form-check">
-        <label class="form-check-label" for="{{label.id}}">
-          <input type="checkbox" class="form-check-input compare-checkbox" onclick="_versions_handleSelectClick()" value={{label.id}} />
-          <a href=/data/{{label.id}} class="text-sml text-stone-900" target="_blank">
-            <h6 class="text-xl text-blue-700 group-hover:underline">
-              {{label.product_name}} ({{label.version_date}})
-            </h6>
-          </a>
-        </label>
-      </div>
-      {% endfor %}
-      <button type="button" onclick="_versions_handleCompareSubmit()" class="btn btn-primary">
-
-        Compare Two Versions
-      </button>
-    </form>
-  </div>
-  <br>
-  {% for section in product_sections %}
+    <h1> {{ drug_label.product_name }}</h1>
+    <div class="row">
+      <dl>
+        <dt>Generic Name: <b>{{ drug_label.generic_name }}</b></dt>
+        <dt>Version Date: <b>{{ drug_label.version_date }}</b></dt>
+        <dt>Product Number: <b>{{ drug_label.source_product_number }}</b></dt>
+        <dt>Marketing Authorization Holder: <b>{{ drug_label.marketer }}</b></dt>
+        <dt>Source: <b>{{ drug_label.source }}</b></dt>
+        <dt>Go to this <a href="{{ drug_label.link }}">Link</a> for the original source document.</dt>
+        <dt></dt>
+      </dl>
+    </div>
     <hr>
-    <h5>{{ section.section_name }}</h5>
-    <p>{{ section.section_text|safe }}</p>
-  {% endfor %}
+    <h5>List of all versions of <b>{{drug_label.product_name}}:</b></h5>
+    <div class="row">
+      <form name="result_to_compare_form" method="get" action="/compare/compare_versions" target="_blank">
+        {% for label in drug_label_versions %}
+        <div class="form-check">
+          <label class="form-check-label" for="{{label.id}}">
+            <input type="checkbox" class="form-check-input compare-checkbox" onclick="_versions_handleSelectClick()" value={{label.id}} />
+            <a href=/data/{{label.id}} class="text-sml text-stone-900" target="_blank">
+              <h6 class="text-xl text-blue-700 group-hover:underline">
+                {{label.product_name}} ({{label.version_date}})
+              </h6>
+            </a>
+          </label>
+        </div>
+        {% endfor %}
+        <button type="button" onclick="_versions_handleCompareSubmit()" class="btn btn-primary">
+          Compare Two Versions
+        </button>
+      </form>
+    </div>
+    <hr>
+    {% for section in product_sections %}
+      <p><h5>{{ section.section_name }}</h5></p>
+      <p>{{ section.section_text|safe }}</p>
+    {% endfor %}
+  </div>
 {% endblock content %}
+
 {% block footer_scripts %}
   <script>
     const _versions_COMPARE_CHECKBOX = "compare-checkbox";
@@ -75,7 +75,7 @@
 
     /**
      * Fired every time the user clicks on the checkbox
-     * Essentially limits the user to just 2 drug labels to compare.
+     * Limits the user to just 2 drug labels to compare.
      */
     function _versions_handleSelectClick() {
       const selectedResults = document.querySelectorAll(
@@ -103,18 +103,13 @@
         firstDrug.name = 'first-label';
         secondDrug.name = 'second-label';
 
-        if (selectedResults.length === 3) {
-          const thirdDrug = selectedResults[2];
-          thirdDrug.name = 'third-label';
-        }
-
         // open the compare page in new tab
         document.result_to_compare_form.submit();
 
         return;
       }
       else {
-        window.alert("Please select 2 or 3 labels to compare.");
+        window.alert("Please select 2 versions to compare.");
         return;
       }
     }

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -18,6 +18,8 @@ def single_label_view(request, drug_label_id):
         product_sections = ProductSection.objects.filter(label_product_id=label_product.id).all()
         for section in product_sections:
             print(f"section_name: {section.section_name}")
+            if drug_label.source == "EMA":
+                section.section_text = section.section_text.replace("\n", "<br>")
     except ObjectDoesNotExist:
         product_sections = []
 

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -20,8 +20,13 @@ def single_label_view(request, drug_label_id):
             print(f"section_name: {section.section_name}")
     except ObjectDoesNotExist:
         product_sections = []
+
+    # get all drug labels with the same product_name
+    drug_label_versions = DrugLabel.objects.filter(product_name=drug_label.product_name).order_by('-version_date')
+
     context = {
         "drug_label": drug_label,
         "product_sections": product_sections,
+        "drug_label_versions": drug_label_versions,
     }
     return render(request, "data/single_label.html", context)

--- a/dle/search/templates/search/search_results/search_results.html
+++ b/dle/search/templates/search/search_results/search_results.html
@@ -1,7 +1,7 @@
 {% extends "search/base.html" %} {% block content %}
 
 {% if search_results %}
-<form name="result_to_compare_form" method="get" action="/compare/compare_result" target="_blank">
+<form name="result_to_compare_form" method="get" action="/compare/compare_labels" target="_blank">
 
     <div class="width-max h-16 bg-white sticky top-0 shadow-lg">
       <div class="flex justify-end py-2">
@@ -67,7 +67,7 @@
      * @return {bool} True if number of selected checkboxes is at the limit
      */
     function _searchresult_isAtLimit(selectedNodes) {
-      return selectedNodes.length === 2;
+      return selectedNodes.length === 3;
     }
 
     /**
@@ -111,19 +111,26 @@
         `input.${_searchresult_COMPARE_CHECKBOX}:checked`
       );
 
-      switch(_searchresult_isAtLimit(selectedResults)) {
-        case true:
-          const [firstDrug, secondDrug] = selectedResults;
-          firstDrug.name = 'first-label';
-          secondDrug.name = 'second-label';
+      const selectedResults_length = selectedResults.length;
 
-          // open the compare page in new tab
-          document.result_to_compare_form.submit();
+      if (selectedResults.length >= 2) {
+        const [firstDrug, secondDrug] = selectedResults;
+        firstDrug.name = 'first-label';
+        secondDrug.name = 'second-label';
 
-          return;
-        case false:
-          window.alert("Please select at least 2 labels");
-          return;
+        if (selectedResults.length === 3) {
+          const thirdDrug = selectedResults[2];
+          thirdDrug.name = 'third-label';
+        }
+
+        // open the compare page in new tab
+        document.result_to_compare_form.submit();
+
+        return;
+      }
+      else {
+        window.alert("Please select 2 or 3 labels to compare.");
+        return;
       }
     }
 


### PR DESCRIPTION
- added a new route `compare/compare_versions` to display version comparison
- allows comparing of 2 versions of the same drug label
- updated `data/single_label.html` to list all versions of the same drug label
- checkbox seleting versions from single label view and click `Compare Two Versions `will display different versions
- section content is shown by clicking on collapsible buttons
- diff text is highlighted in red
- section text better formatted using `|safe`
- Issues with `|safe`:
  - html tags in raw text interfere with our styling and highlighting html tags
  -  it messes up some diff red text highlighting 
  - it messes up the column displays for some sections 
