### PR TITLE
Ky/57 wrap django template value injection with double quotes

### DIFF
--- a/dle/dle/settings.py
+++ b/dle/dle/settings.py
@@ -101,7 +101,8 @@ DATABASES = {
         "NAME": "dle",
         "USER": "dle_user",
         "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
-        "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
+        "HOST": "44.238.69.61",
+        # os.environ.get("DATABASE_HOST", "drug-label-db.org"),
         "PORT": "3306",
     }
 }

--- a/dle/dle/settings.py
+++ b/dle/dle/settings.py
@@ -101,8 +101,7 @@ DATABASES = {
         "NAME": "dle",
         "USER": "dle_user",
         "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
-        "HOST": "44.238.69.61",
-        # os.environ.get("DATABASE_HOST", "drug-label-db.org"),
+        "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
         "PORT": "3306",
     }
 }

--- a/dle/search/templates/search/search_landing/search_form.html
+++ b/dle/search/templates/search/search_landing/search_form.html
@@ -1,7 +1,24 @@
-<form method="get" action="/search/results">
+<form id="search_landing_form" method="get" action="/search/results" onsubmit="displaySearchIndicator()">
+  <div class="flex justify-center">
+  <div id="progress_container"></div>
+</div>
   {% include "search/search_landing/search_form_text_input.html" %}
   <div class="mt-3">
     <span>Narrow search results by ...</span>
     {% include "search/search_landing/additional_filters.html" %}
   </div>
 </form>
+
+{% block footerscripts %}
+<script>
+
+  function displaySearchIndicator() {
+    
+    const inputSearchText = document.getElementById("search_text");
+    inputSearchText.readOnly = true;
+    inputSearchText.classList.add("bg-slate-200");
+    const progressContainer = document.getElementById("progress_container");
+    progressContainer.innerHTML = "Processing search...";
+  }
+</script>
+{% endblock %}

--- a/dle/search/templates/search/search_landing/search_form_text_input.html
+++ b/dle/search/templates/search/search_landing/search_form_text_input.html
@@ -11,8 +11,9 @@
     required
   />
   <div class="absolute top-4 right-3">
-    <button>
+    <button id="my_search_button">
       <svg
+        id="magnifying_icon_svg"
         xmlns="http://www.w3.org/2000/svg"
         class="h-6 w-6"
         fill="none"

--- a/dle/search/templates/search/search_results/results_agency_select.html
+++ b/dle/search/templates/search/search_results/results_agency_select.html
@@ -8,7 +8,7 @@
       aria-label="Default select agency"
     >
     {% if search_request_object.select_agency != '' %}
-        <option value={{search_request_object.select_agency}}>{{search_request_object.select_agency}}</option>
+        <option value="{{search_request_object.select_agency}}">{{search_request_object.select_agency}}</option>
     {% else %}
         <option selected value="">any agency</option>
     {% endif %}

--- a/dle/search/templates/search/search_results/results_brand_name_input.html
+++ b/dle/search/templates/search/search_results/results_brand_name_input.html
@@ -15,7 +15,7 @@
       aria-label="Default brand_name"
       list="brand_name_typeahead_list"
       placeholder="any brand name"      
-      value={{search_request_object.brand_name_input}}
+      value="{{search_request_object.brand_name_input}}"
     />
     {% else %}      
     <input

--- a/dle/search/templates/search/search_results/results_generic_name_input.html
+++ b/dle/search/templates/search/search_results/results_generic_name_input.html
@@ -15,7 +15,7 @@
       aria-label="Default generic_name"
       list="generic_name_typeahead_list"
       placeholder="any generic name"      
-      value={{search_request_object.generic_name_input}}
+      value="{{search_request_object.generic_name_input}}"
     />
     {% else %}      
     <input

--- a/dle/search/templates/search/search_results/results_manufacturer_input.html
+++ b/dle/search/templates/search/search_results/results_manufacturer_input.html
@@ -15,7 +15,7 @@
       aria-label="Default manufacturer"
       list="manufacturer_typeahead_list"
       placeholder="any manufacturer"
-      value={{search_request_object.manufacturer_input}}
+      value="{{search_request_object.manufacturer_input}}"
     />
     {% else %}
     <input

--- a/dle/search/templates/search/search_results/results_search_input.html
+++ b/dle/search/templates/search/search_results/results_search_input.html
@@ -9,7 +9,7 @@
       placeholder="Search for text within drug labels (e.g. rash)"
       size="70"
       list="search_typeahead_list"
-      value={{search_request_object.search_text}}
+      value="{{search_request_object.search_text}}"
       required
     />
     <div class="absolute top-3 right-2">

--- a/dle/search/templates/search/search_results/results_section_select.html
+++ b/dle/search/templates/search/search_results/results_section_select.html
@@ -5,7 +5,7 @@
     <select name="select_section" class="h-10 w-52 px-3 py-1.5 shadow border border-solid border-gray-300 rounded"
         aria-label="Default select section">
         {% if search_request_object.select_section != '' %}
-        <option selected value={{search_request_object.select_section}}>{{search_request_object.select_section}}
+        <option selected value="{{search_request_object.select_section}}">{{search_request_object.select_section}}
         </option>
         {% else %}
         <option selected value="">any section</option>

--- a/dle/search/templates/search/search_results/search_results.html
+++ b/dle/search/templates/search/search_results/search_results.html
@@ -29,15 +29,14 @@
 {% for result, highlighted_text in search_results %}
 <div class="flex my-8 items-center">
   <div class="md:ml-48 w-1/2">
-    <p class="text-sm"><i>{{result.source}} - {{result.version_date}}</i></p>
     <a href=/data/{{result.id}} class="text-base text-stone-900" target="_blank">
-      {{result.generic_name}} // {{result.marketer}}
+      {{result.generic_name}} — {{result.marketer}}
     </a>
     <a href=/data/{{result.id}} target="_blank">
       <h2 class="text-xl text-blue-700 group-hover:underline">
         {{result.product_name}}
       </h2>
-      <p class="text-gray-800">...{{highlighted_text|safe}}...</p>
+      <div class="text-gray-800"> <div class="text-sm italic">{{result.source}} {{result.version_date}}</div>...{{highlighted_text|safe}}...</div>
     </a>
   </div>
   <div>
@@ -59,7 +58,7 @@
     <h2 class="text-lg mt-14">
       <b>No results found</b>
     </h2>
-    <a class="text-xl text-blue-700 group-hover:underline cursor-pointer" onClick="javascript:history.go(-1);">Refine
+    <a class="text-xl text-blue-700 group-hover:underline cursor-pointer" href=/search >Refine
       your search...</a>
   </div>
 </div>

--- a/dle/search/views.py
+++ b/dle/search/views.py
@@ -49,7 +49,7 @@ def list_search_results(request: HttpRequest) -> HttpResponse:
         "type_ahead_brand_name": TYPE_AHEAD_MAPPING["brand_name"],
         "type_ahead_section_name": TYPE_AHEAD_MAPPING["section_name"],
     }
-    print(search_request_object)
+
     return render(request, "search/search_results/search_results.html", context=context)
 
 


### PR DESCRIPTION
This PR fixes the Django Templating string escaping on unquoted variables when forwarding the values to the search results page. Also adds a search indicator when search is being performed and moves the source and version date of the label to under the brand name to mimic google's styling.