### PR TITLE
remove readonly attribute that breaks on going back to the previous page

### DIFF
--- a/dle/search/templates/search/search_landing/search_form.html
+++ b/dle/search/templates/search/search_landing/search_form.html
@@ -15,7 +15,6 @@
   function displaySearchIndicator() {
     
     const inputSearchText = document.getElementById("search_text");
-    inputSearchText.readOnly = true;
     inputSearchText.classList.add("bg-slate-200");
     const progressContainer = document.getElementById("progress_container");
     progressContainer.innerHTML = "Processing search...";


### PR DESCRIPTION
1 line change for removing the readonly attribute that is applied when the user clicks submit