### PR TITLE
Sam/update singlelabel view

### DIFF
--- a/dle/data/templates/data/single_label.html
+++ b/dle/data/templates/data/single_label.html
@@ -14,8 +14,8 @@
       </dl>
     </div>
     <hr>
-    <h5>List of all versions of <b>{{drug_label.product_name|title}}</b> with NDC code <b>{{drug_label.source_product_number}}:</b></h5>
-    <p>(select any two versions and to compare them.)</p>
+    <h5>List of all versions with the same <i>product number</i> <b>({{drug_label.source_product_number}}):</b></h5>
+    <p>(select any two versions to compare)</p>
     <div class="row">
       <form name="result_to_compare_form" method="get" action="/compare/compare_versions" target="_blank">
         {% for label in drug_label_versions %}
@@ -25,7 +25,7 @@
               <a href="{% url 'data:single_label_view' drug_label_id=label.id %}" class="text-sml text-stone-900" target="_blank">
                 <strong>
                   <tr>
-                    <td>{{label.product_name}} |</td>
+                    <td>{{label.product_name|title}} |</td>
                     <td>{{label.source_product_number}} |</td>
                     <td>{{label.source}}</td>
                     <td>({{label.version_date}})</td>
@@ -57,7 +57,7 @@
     <!-- display each section's text  -->
     {% for section in sections %}
     <div class="row" id="{{section.section_name|cut:' '}}" style="margin-top: 10px;">
-      <table>
+      <table style="width:100%"></table>
         <tr>
           <th><h5>{{ section.section_name|title }}</h5></th>
         </tr>
@@ -66,7 +66,7 @@
         </tr>
         <tr>
           <td>
-            <a href="#topdiv">Go to the top</a>.
+            <a href="#topdiv">Go to the top.</a>
           </td>
         </tr>
       </table>

--- a/dle/data/templates/data/single_label.html
+++ b/dle/data/templates/data/single_label.html
@@ -1,4 +1,5 @@
 {% extends "search/base.html" %}
+
 {% block content %}
   <div class="container-fluid" id="topdiv">
     <h1> {{ drug_label.product_name|title }}</h1>
@@ -57,7 +58,12 @@
     <!-- display each section's text  -->
     {% for section in sections %}
     <div class="row" id="{{section.section_name|cut:' '}}" style="margin-top: 10px;">
-      <table style="width:100%"></table>
+      <table style="width:100%">
+        <tr>
+          <td>
+            <hr>
+          </td>
+        </tr>
         <tr>
           <th><h5>{{ section.section_name|title }}</h5></th>
         </tr>

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -35,6 +35,17 @@ def single_label_view(request, drug_label_id, search_text=""):
                             text += f"{word} "
             else:
                 text = section.section_text
+
+            # convert common xml tags to html tags
+            text = text.replace('<list listtype="unordered" ', '<ul ')
+            text = text.replace('<list', '<ul ')
+            text = text.replace('</list>', '</ul>')
+            text = text.replace('<item', '<li')
+            text = text.replace('</item>', '</li>')
+            text = text.replace('<paragraph', '<p')
+            text = text.replace('</paragraph>', '</p>')
+            text = text.replace('<linkhtml', '<a')
+            text = text.replace('</linkhtml>', '</a>')
             
             if drug_label.source == "EMA":
                 sections_dict[section.section_name]["section_text"] = text.replace("\n", "<br>")


### PR DESCRIPTION
This PR updates the Single Label page:
- Converted section text html tags for better formatting of section text.
- Section text is now properly formatted (newlines, bullet points, paragraphs separtions ...)
- added break lines between sections