### PR TITLE
log out functionality bug

### DIFF
--- a/dle/search/views.py
+++ b/dle/search/views.py
@@ -9,7 +9,6 @@ from . import services as SearchService
 from data.models import DrugLabel
 
 # NOTE comment out cache decoractors when doing development to view updates to your front-end templates.
-@cache_page(60 * 20) # cache for 20 mins
 def index(request: HttpRequest) -> HttpResponse:
     """Landing page search view."""
     TYPE_AHEAD_MAPPING = get_type_ahead_mapping()


### PR DESCRIPTION
This PR fixes two bugs:

1. after logging in, user still sees "login" and "register" links instead of "My Label" and "Logout" links.
2. currently, clicking Drug Label Explorer link after logging out takes user back into logged in state. User should be able to go to main search page in logged-out state.

- This was due to the `cash_page` decorator applied on `index()` function in search/views.py 
- Removing it fixs both bugs.

Note: ignore the 'fix-base-html' misleading naming of the branch, the fix was in views not in base.html

Closes #93 