### PR TITLE
fixed highlighting in single label view

### DIFF
--- a/dle/data/util.py
+++ b/dle/data/util.py
@@ -1,0 +1,63 @@
+
+def highlight_query_string(text: str, qstring: str) -> str:
+    """
+    Highlights query word/phrases in input text by surrouding them with <span> tags
+    Args:
+        text: Section raw text from db
+        qstring: A query string from search result page (could be in single/doubl quotes)
+    Returns:
+        str: A text with the query term highlighted (put b/n <span> tags)
+    """
+    # if qstring in double quotes, find & highligh full query str
+    if qstring.startswith('"') and qstring.endswith('"'):
+        qlist = [qstring[1:-1]]
+
+    # if qstring in single quotes, find & highligh full query str
+    elif qstring.startswith("'") and qstring.endswith("'"):
+        qlist = [qstring[1:-1]]
+
+    # else highlight each word in the query str, separatly
+    else:
+        qlist = qstring.split()
+
+    result_text = text
+
+    for qterm in qlist:
+        length = len(qterm)
+        index = 0
+        output_text = ""
+        subtext = result_text[0:]
+        while index != -1:
+            index = subtext.find(qterm)
+            if index == -1:
+                output_text += subtext
+            else:
+                output_text += subtext[0:index]
+                output_text += f"<span style='background-color:yellow'>" 
+                output_text += subtext[index: index + length]
+                output_text += "</span>"
+                subtext = subtext[index + length:]
+
+        result_text = output_text
+
+    return result_text
+
+def reformat_html_tags_in_raw_text(text: str) -> str:
+    """
+    Replaces difficult to render common tags in the raw text with better html tags.
+    Args:
+        text: Section raw text from db
+    Returns:
+        str: Section text with converted html tags
+    """
+    text = text.replace('<list listtype="unordered" ', '<ul ')
+    text = text.replace('<list', '<ul ')
+    text = text.replace('</list>', '</ul>')
+    text = text.replace('<item', '<li')
+    text = text.replace('</item>', '</li>')
+    text = text.replace('<paragraph', '<p')
+    text = text.replace('</paragraph>', '</p>')
+    text = text.replace('<linkhtml', '<a')
+    text = text.replace('</linkhtml>', '</a>')
+
+    return text

--- a/dle/data/util.py
+++ b/dle/data/util.py
@@ -8,6 +8,10 @@ def highlight_query_string(text: str, qstring: str) -> str:
     Returns:
         str: A text with the query term highlighted (put b/n <span> tags)
     """
+    # if qstring is empty, return text as is
+    if qstring == "":
+      return text
+
     # if qstring in double quotes, find & highligh full query str
     if qstring.startswith('"') and qstring.endswith('"'):
         qlist = [qstring[1:-1]]
@@ -41,6 +45,7 @@ def highlight_query_string(text: str, qstring: str) -> str:
         result_text = output_text
 
     return result_text
+
 
 def reformat_html_tags_in_raw_text(text: str) -> str:
     """

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -3,6 +3,7 @@ from django.http import HttpResponse
 from .models import DrugLabel, LabelProduct, ProductSection
 from django.core.exceptions import ObjectDoesNotExist
 from compare.util import *
+from .util import *
 
 
 def index(request):
@@ -26,28 +27,12 @@ def single_label_view(request, drug_label_id, search_text=""):
             # If navigating from search result to single label view
             # highlight the search text within the single label section text
             if search_text != "":
-                text = ""
-                search_words = search_text.split()
-                search_words = [word.lower() for word in search_words]
-                for word in section.section_text.split():
-                    if word.lower() in search_words:
-                        text += f"<span style='background-color:yellow'> {word} </span>"
-                    else:
-                        text += word + " "
-
+                text = highlight_query_string(section.section_text, search_text)
             else:
                 text = section.section_text
 
             # convert common xml tags to html tags
-            text = text.replace('<list listtype="unordered" ', '<ul ')
-            text = text.replace('<list', '<ul ')
-            text = text.replace('</list>', '</ul>')
-            text = text.replace('<item', '<li')
-            text = text.replace('</item>', '</li>')
-            text = text.replace('<paragraph', '<p')
-            text = text.replace('</paragraph>', '</p>')
-            text = text.replace('<linkhtml', '<a')
-            text = text.replace('</linkhtml>', '</a>')
+            text = reformat_html_tags_in_raw_text(text)
             
             if drug_label.source == "EMA":
                 sections_dict[section.section_name]["section_text"] = text.replace("\n", "<br>")

--- a/dle/data/views.py
+++ b/dle/data/views.py
@@ -26,10 +26,7 @@ def single_label_view(request, drug_label_id, search_text=""):
             
             # If navigating from search result to single label view
             # highlight the search text within the single label section text
-            if search_text != "":
-                text = highlight_query_string(section.section_text, search_text)
-            else:
-                text = section.section_text
+            text = highlight_query_string(section.section_text, search_text)
 
             # convert common xml tags to html tags
             text = reformat_html_tags_in_raw_text(text)


### PR DESCRIPTION
This PR:
- fixes partial search query highlighting.
- query such as **blood pressure** will now highlight all instances of **blood** and **pressure**
- exact matches for queries in double or single quotes like **"blood pressure"** or **'blood pressure'** will now be highlighted (including those not surrounded by white space such as **blood pressure,** with a trailing comma)

Closes #102 
