### PR TITLE
text highlighting in compare, upper/lower/title cases

### DIFF
--- a/dle/data/util.py
+++ b/dle/data/util.py
@@ -9,6 +9,8 @@ def highlight_query_string(text: str, qstring: str) -> str:
     Returns:
         str: A text with the query term highlighted (put b/n <span> tags)
     """
+    text_lower = input_text.lower()
+
     # if qstring is empty, return text as is
     if qstring == "":
       return text
@@ -34,7 +36,7 @@ def highlight_query_string(text: str, qstring: str) -> str:
     # get (index, "qterm") tuples in the input text
     positions = []
     for qterm in set(qlist):
-        positions += [(_.start(), qterm) for _ in re.finditer(qterm, text)]
+        positions += [(_.start(), qterm) for _ in re.finditer(qterm, text_lower)]
 
     if positions == []:
         return text

--- a/dle/data/util.py
+++ b/dle/data/util.py
@@ -1,3 +1,4 @@
+import re
 
 def highlight_query_string(text: str, qstring: str) -> str:
     """
@@ -24,28 +25,39 @@ def highlight_query_string(text: str, qstring: str) -> str:
     else:
         qlist = qstring.split()
 
-    result_text = text
 
-    for qterm in qlist:
-        length = len(qterm)
-        index = 0
-        output_text = ""
-        subtext = result_text[0:]
-        while index != -1:
-            index = subtext.find(qterm)
-            if index == -1:
-                output_text += subtext
-            else:
-                output_text += subtext[0:index]
-                output_text += f"<span style='background-color:yellow'>" 
-                output_text += subtext[index: index + length]
-                output_text += "</span>"
-                subtext = subtext[index + length:]
+    # include upper, title, capitalized cases of the query strings
+    qlist += [qterm.upper() for qterm in qlist] \
+           + [qterm.capitalize() for qterm in qlist] \
+           + [qterm.title() for qterm in qlist]
 
-        result_text = output_text
+    # get (index, "qterm") tuples in the input text
+    positions = []
+    for qterm in set(qlist):
+        positions += [(_.start(), qterm) for _ in re.finditer(qterm, text)]
 
-    return result_text
+    if positions == []:
+        return text
 
+    positions.sort()
+    # iterate through positions and insert <span> tags in text
+    output_text = ""
+    length = len(positions)
+    start = 0
+    end = positions[0][0]
+
+    for i in range(length):
+        output_text += text[start:end]
+        output_text += f"<span style='background-color:yellow'>"
+        output_text += positions[i][1]
+        output_text += "</span>"
+        start = end + len(positions[i][1])
+        if i < length - 1:
+            end = positions[i+1][0]
+
+    output_text += text[start:len(text)]
+
+    return output_text
 
 def reformat_html_tags_in_raw_text(text: str) -> str:
     """

--- a/dle/dle/settings.py
+++ b/dle/dle/settings.py
@@ -95,25 +95,13 @@ WSGI_APPLICATION = "dle.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
-# DATABASES = {
-#     "default": {
-#         "ENGINE": "django.db.backends.mysql",
-#         "NAME": "dle",
-#         "USER": "dle_user",
-#         "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
-#         "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
-#         "PORT": "3306",
-#     }
-# }
-
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
         "NAME": "dle",
         "USER": "dle_user",
-        "PASSWORD": "uDyvfMXHIKCJ",
-        # 'HOST': '172.31.12.231', # private IP
-        "HOST": "44.238.69.61",  # public IP
+        "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
+        "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
         "PORT": "3306",
     }
 }

--- a/dle/dle/settings.py
+++ b/dle/dle/settings.py
@@ -95,13 +95,25 @@ WSGI_APPLICATION = "dle.wsgi.application"
 # Database
 # https://docs.djangoproject.com/en/4.0/ref/settings/#databases
 
+# DATABASES = {
+#     "default": {
+#         "ENGINE": "django.db.backends.mysql",
+#         "NAME": "dle",
+#         "USER": "dle_user",
+#         "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
+#         "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
+#         "PORT": "3306",
+#     }
+# }
+
 DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.mysql",
         "NAME": "dle",
         "USER": "dle_user",
-        "PASSWORD": os.environ.get("DATABASE_PASSWORD", "uDyvfMXHIKCJ"),
-        "HOST": os.environ.get("DATABASE_HOST", "drug-label-db.org"),
+        "PASSWORD": "uDyvfMXHIKCJ",
+        # 'HOST': '172.31.12.231', # private IP
+        "HOST": "44.238.69.61",  # public IP
         "PORT": "3306",
     }
 }

--- a/dle/search/templates/search/search_results/search_results.html
+++ b/dle/search/templates/search/search_results/search_results.html
@@ -42,6 +42,7 @@
     <div class="my-2 py-2">
       <form id="id_compare_form" name="result_to_compare_form" method="get" action="/compare/compare_labels"
         target="_blank">
+        <input type="hidden" id="search_text" name="search_text" value="{{ search_request_object.search_text }}">
         <button type="button" onclick="_searchresult_handleCompareSubmit()"
           class="flex mr-8 items-center px-2 py-2 font-medium tracking-wide text-white capitalize transition-colors duration-200 transform bg-blue-600 rounded-md hover:bg-blue-500  shadow-lg">
           <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 28 28">


### PR DESCRIPTION
This PR enhances and fixes search text highlighting:
- Only lower case search texts were being highlighted. Now all forms of searched text (lower/upper/title/capitalized cases) are highlighted in sigle label view.
- Search text was not being highlighted when going to comparison view from Search Results page. Now all forms of searched text will be highlighted in compare pages.


Closes #105